### PR TITLE
Support resubs

### DIFF
--- a/.github/workflows/electron-build.yaml
+++ b/.github/workflows/electron-build.yaml
@@ -1,0 +1,18 @@
+name: Windows Electron Build
+
+on: push
+
+jobs:
+  build-win:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm install
+      - run: npx @electron/packager ./ --platform=win32 --out=dist/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: subtimer
+          path: dist

--- a/twitchListener.js
+++ b/twitchListener.js
@@ -105,6 +105,9 @@ class TwitchListener extends EventEmitter {
                     if (message.metadata.subscription_type === 'channel.subscribe') {
                         subathon_state.addSub(event.tier, event)
                     }
+                    if (message.metadata.subscription_type === 'channel.subscription.message') {
+                        subathon_state.addSub(event.tier, event)
+                    }
                     if (message.metadata.subscription_type === 'channel.cheer') {
                         subathon_state.addBits(event.bits, event)
                     }
@@ -171,6 +174,12 @@ class TwitchListener extends EventEmitter {
         const subscriptions = [
             {
                 type: 'channel.subscribe',
+                version: '1',
+                condition: { broadcaster_user_id: this.#broadcasterId },
+                transport: { method: 'websocket', session_id: sessionId }
+            },
+            {
+                type: 'channel.subscription.message',
                 version: '1',
                 condition: { broadcaster_user_id: this.#broadcasterId },
                 transport: { method: 'websocket', session_id: sessionId }


### PR DESCRIPTION
The [twitch documentation](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelsubscribe) states:

> The `channel.subscribe` subscription type sends a notification when a specified channel receives a subscriber. This does not include resubscribes.

To also pick up resubs, this PR adds the `channel.subscription.message` event.

Also adds a github action because I can't be bothered to keep uploading and sharing builds myself.