### PR TITLE
Small bugfixes

### DIFF
--- a/hhmmss.js
+++ b/hhmmss.js
@@ -13,7 +13,7 @@ function toHhMmSs(v) {
   const minutes = Math.floor(v / 60) % 60
   const seconds = v % 60
   let str = seconds.toString().padStart(2, '0')
-  if (minutes > 0) str = `${hours > 0 ? minutes.toString().padStart(2, '0') : minutes}:${str}`
+  if (minutes > 0 || hours > 0) str = `${hours > 0 ? minutes.toString().padStart(2, '0') : minutes}:${str}`
   if (hours > 0) str = `${hours}:${str}`
   return str
 }

--- a/twitchListener.js
+++ b/twitchListener.js
@@ -103,7 +103,10 @@ class TwitchListener extends EventEmitter {
                 if (message.metadata?.message_type === 'notification') {
                     const event = message.payload.event;
                     if (message.metadata.subscription_type === 'channel.subscribe') {
-                        subathon_state.addSub(event.tier, event)
+                        // Regular subs are counted when the message is sent with `channel.subscription.message`
+                        if (event.is_gift) {
+                            subathon_state.addSub(event.tier, event)
+                        }
                     }
                     if (message.metadata.subscription_type === 'channel.subscription.message') {
                         subathon_state.addSub(event.tier, event)


### PR DESCRIPTION
- When rendering time values to HH:MM:SS format, the code would skip rendering minutes if they were set to 0. This is bad because if hours are non-zero it generated HH:SS.
- Resubs would be double counted because they send both a `channel.subscribe` event as well as a `channel.subscription.message` event. Instead, only accept the `channel.subscription.message` event because that's what the streamer will actually see in their activity feed.